### PR TITLE
Fix crash when metadata values contain =

### DIFF
--- a/tft_moode_coverart.py
+++ b/tft_moode_coverart.py
@@ -135,7 +135,7 @@ def getMoodeMetadata(filename):
         i = 0
         while i < len(nowplayingmeta):
             # traverse list converting to a dictionary
-            (key, value) = nowplayingmeta[i].split('=')
+            (key, value) = nowplayingmeta[i].split('=', 1)
             metaDict[key] = value
             i += 1
         


### PR DESCRIPTION
For example, it would crash with the following entry that contained more than one = in the URL:
`file=http://192.168.0.73:57645/proxy/gdrive/stream/ZGFwZXRjdTIxQGdtYWlsLmNvbQ==/1seIwDMl1oO3RHom-svSHRlSTgDNx0eHy.m4a`